### PR TITLE
Add build workflow and amd64 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Build
+      run: ./build.sh
+
+    # - name: Test
+    #   run: go test -v ./...
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: drop
+        path: .publish/

--- a/build.sh
+++ b/build.sh
@@ -4,14 +4,20 @@ VERSION=0.2.0
 
 rm -rf .publish/ && mkdir .publish
 
-GOOS=linux GOARCH=amd64 go build -o .publish/terraform-provider-akc_v${VERSION}
+GOOS=linux GOARCH=amd64 go build -o .publish/linux_amd64/terraform-provider-akc_v${VERSION}
 
-cd .publish
+cd .publish/linux_amd64
 zip -r terraform-provider-akc_${VERSION}_linux_amd64.zip terraform-provider-akc_v${VERSION}
 shasum -a 256 terraform-provider-akc_${VERSION}_linux_amd64.zip > terraform-provider-akc_${VERSION}_SHA256SUMS
-gpg --detach-sign terraform-provider-akc_${VERSION}_SHA256SUMS
+#gpg --detach-sign terraform-provider-akc_${VERSION}_SHA256SUMS
 rm terraform-provider-akc_v${VERSION}
 
-cd ..
+cd ../..
 
-# GOOS=windows GOARCH=amd64 go build -o "terraform-provider-akc_v${VERSION}.exe"
+GOOS=windows GOARCH=amd64 go build -o .publish/win_amd64/terraform-provider-akc_v${VERSION}.exe
+
+cd .publish/win_amd64
+zip -r terraform-provider-akc_${VERSION}_win_amd64.zip terraform-provider-akc_v${VERSION}.exe
+shasum -a 256 terraform-provider-akc_${VERSION}_win_amd64.zip > terraform-provider-akc_${VERSION}_SHA256SUMS
+#gpg --detach-sign terraform-provider-akc_${VERSION}_SHA256SUMS
+rm terraform-provider-akc_v${VERSION}.exe


### PR DESCRIPTION
This change enables a GitHub workflow to build the provider for both
Linux and Windows on amd64 using the original build script. A couple of
notes:

- This change also persists a chmod +x to the ./build.sh in the repo so
  it can be executed in the action
- It appears tests need an Azure context. I've put a build step in but
  commented it out for now to allow this once an environment is ready

Fixes #8 